### PR TITLE
docs: fix misnamed functions in comment / docs

### DIFF
--- a/projects/functions/secret-secrets/02-dr-on/README.md
+++ b/projects/functions/secret-secrets/02-dr-on/README.md
@@ -32,6 +32,6 @@ Return: a function with:
 
 ## Files
 
-- `index.ts`: Write your `createCipher` function here
-- `index.test.ts`: Tests verifying `createCipher`
+- `index.ts`: Write your `createAdvancedCipher` function here
+- `index.test.ts`: Tests verifying `createAdvancedCipher`
 - `solution.ts`: Solution code

--- a/projects/functions/secret-secrets/03-the-golden-code/README.md
+++ b/projects/functions/secret-secrets/03-the-golden-code/README.md
@@ -37,6 +37,6 @@ Return: a function with:
 
 ## Files
 
-- `index.ts`: Write your `createCipher` function here
-- `index.test.ts`: Tests verifying `createCipher`
+- `index.ts`: Write your `createCodeCracker` function here
+- `index.test.ts`: Tests verifying `createCodeCracker`
 - `solution.ts`: Solution code

--- a/projects/functions/secret-secrets/03-the-golden-code/index.ts
+++ b/projects/functions/secret-secrets/03-the-golden-code/index.ts
@@ -1,2 +1,2 @@
-// Write your createAdvancedCipher function here! ✨
+// Write your createCodeCracker function here! ✨
 // You'll need to export it so the tests can run it.


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to LearningTypescript! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: N/A: small typo
- [ ] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

`createAdvancedCipher` is from part 2, part 3's README says to write the `createCodeCracker` function. Fixed similar issues in READMEs