### PR TITLE
fix: typos in unions-and-literals

### DIFF
--- a/projects/unions-and-literals/primitive-cooking/02-recipes/index.ts
+++ b/projects/unions-and-literals/primitive-cooking/02-recipes/index.ts
@@ -23,7 +23,7 @@ console.log(`[${group}] ${title}: ${difficulty}/3 difficulty`);
 
 // Send everyone off with a nice closer.
 difficulty = 1;
-group = "desert";
+group = "dessert";
 title = "Biscuits and Coffee";
 console.log(`[${group}] ${title}: ${difficulty}/3 difficulty`);
 

--- a/projects/unions-and-literals/primitive-cooking/03-seating/index.ts
+++ b/projects/unions-and-literals/primitive-cooking/03-seating/index.ts
@@ -44,7 +44,7 @@ console.log(`At the head of the table is... ${headOfTable}`);
 console.log(`Adjacent to the left is: ${adjacentLeft}`);
 console.log(`Adjacent to the right is: ${adjacentRight}`);
 
-console.log(`Further down on the left is: ${adjacentLeft ?? "nobody"}`);
-console.log(`Further down on the right is: ${adjacentRight ?? "nobody"}`);
+console.log(`Further down on the left is: ${furtherLeft ?? "nobody"}`);
+console.log(`Further down on the right is: ${furtherRight ?? "nobody"}`);
 
 export {};

--- a/projects/unions-and-literals/primitive-cooking/03-seating/solution.ts
+++ b/projects/unions-and-literals/primitive-cooking/03-seating/solution.ts
@@ -2,7 +2,7 @@ const headOfTable = "Me!";
 let adjacentLeft: "Chuckie" | "Tommy";
 let adjacentRight: "Chuckie" | "Tommy";
 let furtherLeft: "Angelica" | "Susie" | undefined;
-let furtherRight: "Susie" | "Kimi" | "Edwin" | undefined;
+let furtherRight: "Susie" | "Kimi" | "Timmy" | undefined;
 
 // I always invite Chuckie and Tommy! ♥
 if (Math.random() > 0.5) {
@@ -34,9 +34,9 @@ if (furtherLeft === "Angelica" && furtherRight !== "Susie") {
 	furtherRight = "Kimi";
 }
 
-// If I invited Susie but not Angelica, I'll invite Edwin. They get along well with Susie but not Angelica.
+// If I invited Susie but not Angelica, I'll invite Timmy. They get along well with Susie but not Angelica.
 if (furtherLeft === "Susie") {
-	furtherRight = "Edwin";
+	furtherRight = "Timmy";
 }
 
 console.log(`At the head of the table is... ${headOfTable}`);
@@ -44,7 +44,7 @@ console.log(`At the head of the table is... ${headOfTable}`);
 console.log(`Adjacent to the left is: ${adjacentLeft}`);
 console.log(`Adjacent to the right is: ${adjacentRight}`);
 
-console.log(`Further down on the left is: ${adjacentLeft ?? "nobody"}`);
-console.log(`Further down on the right is: ${adjacentRight ?? "nobody"}`);
+console.log(`Further down on the left is: ${furtherLeft ?? "nobody"}`);
+console.log(`Further down on the right is: ${furtherRight ?? "nobody"}`);
 
 export {};


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

None of this applies, as the problem were typos.

## Overview

...02-recipes/index.ts Changed the spelling from "desert" to "dessert"
...03-seating/solution.ts had a literal type "Edwin" while ...03-seating/index.ts had "Timmy".
