### PR TITLE
fix: corrected test case types for text-processor

### DIFF
--- a/projects/arrays/text-processor/src/index.test.ts
+++ b/projects/arrays/text-processor/src/index.test.ts
@@ -22,7 +22,7 @@ describe(alignTexts, () => {
 		});
 	});
 
-	test.each([
+	const cases: [string[], index.AlignmentOptions, string[][]][] = [
 		[[""], { width: 0 }, [[""]]],
 		[["", ""], { width: 0 }, [[""], [""]]],
 		[[""], { width: 2 }, [["  "]]],
@@ -113,7 +113,9 @@ describe(alignTexts, () => {
 				["  abc", "  def", "  ghi"],
 			],
 		],
-	])("%j %o", (lines, options, aligned) => {
+	];
+
+	test.each(cases)("%j %o", (lines, options, aligned) => {
 		expect(alignTexts(lines, options)).toEqual(aligned);
 	});
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #160
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The solution causes a `tsc` complaint for `string`s not matching the union of literals `"left" | "middle" | "right"`.

```plaintext
Argument of type '{ width: number; } | { align: string; width: number; }' is not assignable to parameter of type 'AlignmentOptions'.
  Type '{ align: string; width: number; }' is not assignable to type 'AlignmentOptions'.
    Types of property 'align' are incompatible.
      Type 'string' is not assignable to type '"left" | "middle" | "right" | undefined'.
```