### PR TITLE
fix: typo for exercise repo's link in generics > Hidash > Pick Many

### DIFF
--- a/projects/generics/hidash/README.md
+++ b/projects/generics/hidash/README.md
@@ -39,7 +39,7 @@ npm run test -- 1 --watch
 - [1. Unique](./01-unique)
 - [2. Zip](./02-zip)
 - [3. Pick](./03-pick)
-- [4. Pick Many](./04-pickMany)
+- [4. Pick Many](./04-pickmany)
 
 ## Notes
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to LearningTypescript! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #000
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Fix link typo for [Generic/Hidash/4. Pick Many](https://www.learningtypescript.com/generics/hidash/04-pickmany)
