### PR TITLE
fix: assert index as typeof solution in shape-of-types

### DIFF
--- a/projects/classes/the-shape-of-types/src/index.test.ts
+++ b/projects/classes/the-shape-of-types/src/index.test.ts
@@ -5,7 +5,10 @@ import * as solution from "./solution";
 
 const { Demon, Horror, Sorcerer } = process.env.TEST_SOLUTIONS
 	? solution
-	: index;
+	: // In theory, it would be nice to not have to apply this cast
+	  // In practice, TypeScript's structural typing does not play well with # privates
+	  // See https://github.com/LearningTypeScript/projects/issues/183
+	  (index as unknown as typeof solution);
 
 class MockHorror extends Horror {
 	name = "";


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #183
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes for newly introduced TypeScript complaints in the test file. It asserts that the `index` file is the same shape as `solution`, so that TypeScript doesn't think there are _two_ possible versions of each class.