### PR TITLE
fix: inconsistent property names in treasure-hunter

### DIFF
--- a/projects/generics/treasure-hunter/README.md
+++ b/projects/generics/treasure-hunter/README.md
@@ -38,16 +38,16 @@ The `collectTreasure` function should have three runtime parameters:
 - `isFake`: A type predicate function that takes in a `datum` and returns whether it is `Fake`
 - `isReal`: A type predicate function that takes in a `datum` and returns whether it is `Real`
 
-Also create and export a `Buried` interface with a single type parameter.
+Also create and export a `Buried` type with a single type parameter.
 Each `Buried` object can be one of three things:
 
 - An array of the same type of `Buried` objects
 - A `NextArea` object, which can be either:
   - A `Catacomb` shape, with properties:
-    - `contents`: A `Buried` object of the same type
+    - `inside`: A `Buried` object of the same type
     - `type`: `"catacomb"`
   - A `TunnelSystem` shape, with properties:
-    - `tunnels`: An array of `Buried` objects of the same type
+    - `entrances`: An array of `Buried` objects of the same type
     - `type`: `"tunnels"`
 
 The `collectTreasure` function should return an object with three properties:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #222
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Corrects the property names (and description of interface/type) in the README.md to match the intended solution. I think the code has better names.