### PR TITLE
fix: properly describe power comparator in The Shape of Types

### DIFF
--- a/projects/classes/the-shape-of-types/README.md
+++ b/projects/classes/the-shape-of-types/README.md
@@ -40,7 +40,7 @@ It will contain...
 - Property:
   - `name`: An abstract read-only string only visible to the class and its derived classes
 - Public Methods:
-  - `doBattle`: Takes in an opponent `Horror`, and if this horror's `.getPower()` is greater than the opponent's, consumes the opponent _(read more later)_.
+  - `doBattle`: Takes in an opponent `Horror`, and if this horror's `.getPower()` is greater than or equal to the opponent's, consumes the opponent _(read more later)_.
   - `getPower`: Returns the sum of calling `this.getPowerFrom` on each previously consumed opponent _(read more later)_, plus the number of previously consumed opponents
 - Protected Abstract methods:
   - `getPowerFrom`: Takes in a previously consumed opponent and returns a computed power number


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #254
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The code considers it an _or equal then_, so let's go with that in the description.