### PR TITLE
fix: also replace 'typeof solution' assertions when copying solutions

### DIFF
--- a/scripts/copy-solutions.sh
+++ b/scripts/copy-solutions.sh
@@ -2,6 +2,9 @@
 # Projects that use classes with # private members would otherwise report assignability errors.
 find projects -type f -name "*.test.*" -print0 | xargs -0 sed -i '' -e 's/\? solution/\? index/g'
 
+# Similarly, "index as unknown as typeof solution" type assertions are used for class #privates.
+find projects -type f -name "*.test.*" -print0 | xargs -0 sed -i '' -e 's/as typeof solution/as typeof index/g'
+
 for solutionPath in $(find projects -name \*solution\*); do
 	if [[ $solutionPath == */solution.* ]]; then
 		replacedPath=${solutionPath//"solution"/"index"}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #262
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Similar to how `? solution` is replaced with `? index`, `as typeof solution` is now also replaced with `as typeof index`.