### PR TITLE
fix: override # private unions in Horror Factory

### DIFF
--- a/projects/classes/horror-factory/src/index.test.ts
+++ b/projects/classes/horror-factory/src/index.test.ts
@@ -4,7 +4,10 @@ import * as index from "./index";
 import * as solution from "./solution";
 
 const { createDemon, createSorcerer, Horror } = process.env.TEST_SOLUTIONS
-	? solution
+	? // TypeScript treats # privates as unique, even across two otherwise identical classes.
+	  // This assertion "tricks" the type system into treating both Horror classes the same.
+	  // https://github.com/LearningTypeScript/projects/issues/276
+	  (solution as typeof index & typeof solution)
 	: index;
 
 const createMockHorrorSettings = (evil: boolean) => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #276
    * There might be more work to do for tests (I asked in https://github.com/LearningTypeScript/projects/issues/276#issuecomment-1720016386), but we can tackle that separately
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses an `as` assertion to intersect the type of the `index` file on top of the `solution` file. In other words, this tells TypeScript that the type of the `solution` file should also include everything from `index`, making the classes assignable to each other despite having different `#` privates.