### PR TITLE
fix: correct reversed types in 03-split-on

### DIFF
--- a/projects/type-operations/template-literal-type-shenanigans/03-split-on/solution.ts
+++ b/projects/type-operations/template-literal-type-shenanigans/03-split-on/solution.ts
@@ -3,5 +3,11 @@ export type SplitOn<
 	On extends string,
 	Results extends string[] = [],
 > = Text extends `${infer Prefix}${On}${infer Suffix}`
-	? SplitOn<Suffix, On, [Prefix, ...Results]>
-	: [Text, ...Results];
+	? SplitOn<Suffix, On, [...Results, Prefix]>
+	: [...Results, Text];
+
+type Wat1 = SplitOn<"baby", "a">;
+//   ^?
+
+type Wat2 = SplitOn<"hello my baby", " ">;
+//   ^?

--- a/projects/type-operations/template-literal-type-shenanigans/03-split-on/solution.ts
+++ b/projects/type-operations/template-literal-type-shenanigans/03-split-on/solution.ts
@@ -5,9 +5,3 @@ export type SplitOn<
 > = Text extends `${infer Prefix}${On}${infer Suffix}`
 	? SplitOn<Suffix, On, [...Results, Prefix]>
 	: [...Results, Text];
-
-type Wat1 = SplitOn<"baby", "a">;
-//   ^?
-
-type Wat2 = SplitOn<"hello my baby", " ">;
-//   ^?


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #283
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Tested with:

```ts
type Test1 = SplitOn<"baby", "a">;
//   ^? type Test1 = ["b", "by"]

type Test2 = SplitOn<"hello my baby", " ">;
//   ^? type Test2 = ["hello", "my", "baby"]
```

💖 