### PR TITLE
fix: type-operations/array-type-shenanigans/01-flat-filter example

### DIFF
--- a/projects/type-operations/array-type-shenanigans/01-flat-filter/README.md
+++ b/projects/type-operations/array-type-shenanigans/01-flat-filter/README.md
@@ -32,7 +32,7 @@ It should result in a flattened array or tuple type of items that only `extend F
 
 ## Examples
 
-- `FilteredArrayItems<number[], string>` -> `number`
+- `FilteredArrayItems<number[], string>` -> `never`
 - `FilteredArrayItems<(number | string)[], number>` -> `number`
 - `FilteredArrayItems<["a", 1, "b", 2], string>` -> `"a" | "b"`
 


### PR DESCRIPTION
## Overview

The first example results in `never`, not `number`.
