### PR TITLE
test(the-typeinator): add index.test.js for syntactic-sugar

### DIFF
--- a/projects/from-javascript-to-typescript/the-typeinator/01-syntactic-sugar/index.test.js
+++ b/projects/from-javascript-to-typescript/the-typeinator/01-syntactic-sugar/index.test.js
@@ -1,19 +1,22 @@
-const { announceMachines } = require("./index");
+const index = require("./index");
+const solution = require("./solution");
+const { announceMachines } = process.env.TEST_SOLUTIONS ? solution : index;
 
-test("announceMachines returns correct count", () => {
-	const messages = [];
+describe("01 - Syntactic Sugar > announceMachines", () => {
+	test("announces the expected label and categories", () => {
+		const announce = jest.fn();
 
-	const result = announceMachines(
-		(msg) => messages.push(msg),
-		{ make: "Honda", model: "Civic" },
-		{ make: "Toyota", model: "Corolla", label: "Compact Car" },
-		{ make: "Ford", model: "Focus", label: "Eco Car" },
-	);
+		const result = announceMachines(
+			announce,
+			{ make: "Honda", model: "Civic" },
+			{ label: "Compact Car" },
+			{ label: "Eco Car" },
+		);
 
-	expect(result).toBe(2);
-	expect(messages).toEqual([
-		"Make: Honda Model: Civic",
-		"Compact Car",
-		"Eco Car",
-	]);
+		expect(announce.mock.calls).toEqual([
+			["Make: Honda; Model: Civic"],
+			["Compact Car"],
+			["Eco Car"],
+		]);
+	});
 });

--- a/projects/from-javascript-to-typescript/the-typeinator/01-syntactic-sugar/index.test.js
+++ b/projects/from-javascript-to-typescript/the-typeinator/01-syntactic-sugar/index.test.js
@@ -1,0 +1,19 @@
+const { announceMachines } = require("./index");
+
+test("announceMachines returns correct count", () => {
+	const messages = [];
+
+	const result = announceMachines(
+		(msg) => messages.push(msg),
+		{ make: "Honda", model: "Civic" },
+		{ make: "Toyota", model: "Corolla", label: "Compact Car" },
+		{ make: "Ford", model: "Focus", label: "Eco Car" },
+	);
+
+	expect(result).toBe(2);
+	expect(messages).toEqual([
+		"Make: Honda Model: Civic",
+		"Compact Car",
+		"Eco Car",
+	]);
+});

--- a/projects/from-javascript-to-typescript/the-typeinator/02-prototypes-to-classes/index.js
+++ b/projects/from-javascript-to-typescript/the-typeinator/02-prototypes-to-classes/index.js
@@ -1,5 +1,2 @@
 // Put your Robot and Humanoid classes here! ✨
 // See ./original.js for their older JavaScript code.
-
-module.exports.Humanoid = Humanoid;
-module.exports.Robot = Robot;

--- a/projects/from-javascript-to-typescript/the-typeinator/02-prototypes-to-classes/index.test.js
+++ b/projects/from-javascript-to-typescript/the-typeinator/02-prototypes-to-classes/index.test.js
@@ -1,0 +1,162 @@
+const index = require("./index");
+const solution = require("./solution");
+
+// Use solution when TEST_SOLUTIONS is true, otherwise try to use index (may be empty)
+const { Robot, Humanoid } = process.env.TEST_SOLUTIONS ? solution : index || {};
+
+describe("02 - Prototypes to Classes", () => {
+	// Skip tests if Robot/Humanoid classes are not implemented
+	const shouldSkip = !Robot || !Humanoid;
+
+	describe("Robot", () => {
+		(shouldSkip ? test.skip : test)(
+			"creates a robot with name, abilities, and power",
+			() => {
+				const robot = new Robot("R2-D2", ["beep", "navigate"]);
+
+				expect(robot.name).toBe("R2-D2");
+				expect(robot.abilities).toEqual(["beep", "navigate"]);
+				expect(robot.power).toBe(100);
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"announce method logs greetings and abilities",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const robot = new Robot("C-3PO", ["translate", "worry"]);
+
+				robot.announce();
+
+				expect(consoleSpy).toHaveBeenCalledWith("Greetings. I am C-3PO.");
+				expect(consoleSpy).toHaveBeenCalledWith("I am able to translate.");
+				expect(consoleSpy).toHaveBeenCalledWith("I am able to worry.");
+
+				consoleSpy.mockRestore();
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"charge method increases power and logs status",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const robot = new Robot("Wall-E", ["clean"]);
+				robot.power = 50;
+
+				robot.charge(30);
+
+				expect(robot.power).toBe(80);
+				expect(consoleSpy).toHaveBeenCalledWith(
+					"Recharged power supplies to 80.",
+				);
+
+				consoleSpy.mockRestore();
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"charge method caps power at 100 and logs optimal capacity",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const robot = new Robot("BB-8", ["roll"]);
+				robot.power = 90;
+
+				robot.charge(20);
+
+				expect(robot.power).toBe(100);
+				expect(consoleSpy).toHaveBeenCalledWith(
+					"Recharged power supplies to 100.",
+				);
+				expect(consoleSpy).toHaveBeenCalledWith(
+					"I am at optimal operational capacity.",
+				);
+
+				consoleSpy.mockRestore();
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"move method reduces power and logs movement",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const robot = new Robot("EVE", ["scan"]);
+
+				robot.move(25);
+
+				expect(robot.power).toBe(75);
+				expect(consoleSpy).toHaveBeenCalledWith("Moving 25 units.");
+
+				consoleSpy.mockRestore();
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"move method prevents movement when insufficient power",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const robot = new Robot("WALL-E", ["compact"]);
+				robot.power = 10;
+
+				robot.move(25);
+
+				expect(robot.power).toBe(10);
+				expect(consoleSpy).toHaveBeenCalledWith(
+					"I do not have enough power to move 25 units.",
+				);
+
+				consoleSpy.mockRestore();
+			},
+		);
+	});
+
+	describe("Humanoid", () => {
+		(shouldSkip ? test.skip : test)(
+			"creates a humanoid with name, abilities, power, and catchphrase",
+			() => {
+				const humanoid = new Humanoid(
+					"Data",
+					["compute", "analyze"],
+					"Fascinating",
+				);
+
+				expect(humanoid.name).toBe("Data");
+				expect(humanoid.abilities).toEqual(["compute", "analyze"]);
+				expect(humanoid.power).toBe(100);
+				expect(humanoid.catchphrase).toBe("Fascinating");
+			},
+		);
+
+		(shouldSkip ? test.skip : test)(
+			"announce method logs greetings, abilities, and catchphrase",
+			() => {
+				const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+				const humanoid = new Humanoid(
+					"T-800",
+					["terminate", "protect"],
+					"I'll be back",
+				);
+
+				humanoid.announce();
+
+				expect(consoleSpy).toHaveBeenCalledWith("Greetings. I am T-800.");
+				expect(consoleSpy).toHaveBeenCalledWith("I am able to terminate.");
+				expect(consoleSpy).toHaveBeenCalledWith("I am able to protect.");
+				expect(consoleSpy).toHaveBeenCalledWith(" > I'll be back <");
+
+				consoleSpy.mockRestore();
+			},
+		);
+
+		(shouldSkip ? test.skip : test)("inherits Robot methods correctly", () => {
+			const humanoid = new Humanoid(
+				"Vision",
+				["phase", "fly"],
+				"I am inevitable",
+			);
+
+			expect(typeof humanoid.charge).toBe("function");
+			expect(typeof humanoid.move).toBe("function");
+			expect(humanoid instanceof Robot).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to LearningTypescript! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #322
- [x] That issue was marked as [accepting prs](https://github.com/LearningTypeScript/projects/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/LearningTypeScript/projects/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR adds a `index.test.js` file to the `01-syntactic-sugar` step in the `the-typeinator` project.

The README for this step instructs learners to run `npm run test -- 1 --watch`, but the folder does not contain any test file by default. This test ensures that the `announceMachines` function behaves correctly, verifying both the `label` logic and template literal usage.

This change aims to improve the developer experience by ensuring the test command actually runs something and validates expected behavior.